### PR TITLE
Use rawgit.com for getting started code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ http://flouthoc.github.io/minAjax.js/
 #Usage
 Getting Started
 ```html
-<script type="text/javascript" src="https://raw.githubusercontent.com/flouthoc/minAjax.js/master/index.js"></script>
+<script type="text/javascript" src="https://cdn.rawgit.com/flouthoc/minAjax.js/master/minify/index.min.js"></script>
 ```
 
 


### PR DESCRIPTION
From https://rawgit.com/faq#why

> ## Why is this necessary? Can't I just load files from GitHub directly?

> When you request a file from raw.githubusercontent.com or gist.githubusercontent.com, GitHub usually serves it (in the case of JavaScript, HTML, CSS, and some other file types) with a Content-Type of text/plain. As a result, most modern browsers won't actually interpret it as JavaScript, HTML, or CSS.

> They do this because serving raw files from a git repo is relatively inefficient, so they want to discourage people from using their GitHub repos for static file hosting.

> RawGit acts as a caching proxy, forwarding requests to GitHub, caching the responses either for a short time (in the case of rawgit.com URLs) or permanently (in the case of cdn.rawgit.com URLs), and relaying them to your browser with the correct Content-Type headers.

> The caching layer ensures that minimal load is placed on GitHub, and you get quick and easy static file hosting right from a GitHub repo. Everyone's happy!

:beers: for this lib, it is exactly what I needed to hack on some stuff today :smile: 